### PR TITLE
Webkit2gtk improvements

### DIFF
--- a/net.poedit.Poedit.json
+++ b/net.poedit.Poedit.json
@@ -47,7 +47,13 @@
                 {
                     "type": "archive",
                     "url": "https://webkitgtk.org/releases/webkitgtk-2.38.6.tar.xz",
-                    "sha256": "1c614c9589389db1a79ea9ba4293bbe8ac3ab0a2234cac700935fae0724ad48b"
+                    "sha256": "1c614c9589389db1a79ea9ba4293bbe8ac3ab0a2234cac700935fae0724ad48b",
+                    "x-checker-data": {
+                        "type": "html",
+                        "url": "https://webkitgtk.org/releases/",
+                        "version-pattern": "LATEST-STABLE-(\\d[\\.\\d]+\\d)",
+                        "url-template": "https://webkitgtk.org/releases/webkitgtk-$version.tar.xz"
+                    }
                 }
             ]
         },

--- a/net.poedit.Poedit.json
+++ b/net.poedit.Poedit.json
@@ -26,6 +26,44 @@
         "shared-modules/intltool/intltool-0.51.json",
         "shared-modules/libsoup/libsoup-2.4.json",
         {
+            "name": "unifdef",
+            "no-autogen": true,
+            "make-install-args": [
+                "prefix=${FLATPAK_DEST}"
+            ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://dotat.at/prog/unifdef/unifdef-2.12.tar.xz",
+                    "sha256": "43ce0f02ecdcdc723b2475575563ddb192e988c886d368260bc0a63aee3ac400"
+                }
+            ],
+            "cleanup": [
+                "*"
+            ]
+        },
+        {
+            "name": "libjxl",
+            "buildsystem": "cmake-ninja",
+            "config-opts": [
+                "-DCMAKE_BUILD_TYPE=RelWithDebInfo",
+                "-DBUILD_TESTING=OFF"
+            ],
+            "sources": [
+                {
+                    "type": "git",
+                    "url": "https://github.com/libjxl/libjxl.git",
+                    "tag": "v0.8.2",
+                    "commit":"954b460768c08a147abf47689ad69b0e7beff65e",
+                    "disable-shallow-clone": true,
+                    "x-checker-data": {
+                        "type": "git",
+                        "tag-pattern": "^v([\\d.]+)$"
+                    }
+                }
+            ]
+        },
+        {
             "name": "webkit2gtk-4.0",
             "buildsystem": "cmake-ninja",
             "cleanup": [
@@ -46,8 +84,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://webkitgtk.org/releases/webkitgtk-2.38.6.tar.xz",
-                    "sha256": "1c614c9589389db1a79ea9ba4293bbe8ac3ab0a2234cac700935fae0724ad48b",
+                    "url": "https://webkitgtk.org/releases/webkitgtk-2.42.0.tar.xz",
+                    "sha256": "828f95935861fae583fb8f2ae58cf64c63c178ae2b7c2d6f73070813ad64ed1b",
                     "x-checker-data": {
                         "type": "html",
                         "url": "https://webkitgtk.org/releases/",


### PR DESCRIPTION
I don't know if this needs libjpegxl, I added it because it is turned on by default but I don't think it matters much as 45 will be out next week and it'll be included by default in the runtime

If it doesn't need this, for the short window there is a compile arg to turn it off

Let me know if it is preferable to manage the version by hand instead of x-checker. Managing a working copy can be bit of a work.