### PR TITLE
Update Runtime to Gnome 46

### DIFF
--- a/appdata.patch
+++ b/appdata.patch
@@ -1,6 +1,14 @@
---- a/net.poedit.Poedit.appdata.xml	2022-02-12 01:42:12.000000000 +0700
-+++ b/net.poedit.Poedit.appdata.xml	2024-01-14 01:50:06.422242821 +0300
-@@ -21,6 +21,39 @@
+--- a/net.poedit.Poedit.appdata.xml
++++ b/net.poedit.Poedit.appdata.xml
+@@ -14,13 +14,46 @@
+         </p>
+     </description>
+     <screenshots>
+-        <screenshot>
++        <screenshot type="default">
+             <image type="source">https://poedit.net/images/screenshots/linux/poedit-appdata1.png</image>
+         </screenshot>
+     </screenshots>
      <url type="homepage">https://poedit.net</url>
      <url type="bugtracker">https://github.com/vslavik/poedit</url>
      <url type="translate">https://crowdin.com/project/poedit</url>

--- a/disable-cpprestsdk-cpp-warn-error.patch
+++ b/disable-cpprestsdk-cpp-warn-error.patch
@@ -1,0 +1,11 @@
+--- a/Release/CMakeLists.txt
++++ b/Release/CMakeLists.txt
+@@ -15,7 +15,7 @@
+ 
+ enable_testing()
+ 
+-set(WERROR ON CACHE BOOL "Treat Warnings as Errors.")
++set(WERROR OFF CACHE BOOL "Treat Warnings as Errors.")
+ set(CPPREST_EXCLUDE_WEBSOCKETS OFF CACHE BOOL "Exclude websockets functionality.")
+ set(CPPREST_EXCLUDE_COMPRESSION OFF CACHE BOOL "Exclude compression functionality.")
+ set(CPPREST_EXCLUDE_BROTLI ON CACHE BOOL "Exclude Brotli compression functionality.")

--- a/disable-webkit2-gi-warn-error.patch
+++ b/disable-webkit2-gi-warn-error.patch
@@ -1,0 +1,11 @@
+--- a/Source/cmake/FindGI.cmake
++++ b/Source/cmake/FindGI.cmake
+@@ -342,7 +342,7 @@
+         VERBATIM
+         COMMAND_EXPAND_LISTS
+         COMMAND ${CMAKE_COMMAND} -E env "CC=${CMAKE_C_COMPILER}" "CFLAGS=${CMAKE_C_FLAGS}"
+-            "${GI_SCANNER_EXE}" --quiet --warn-all --warn-error --no-libtool
++            "${GI_SCANNER_EXE}" --quiet --warn-all --no-libtool
+             "--output=${gir_path}"
+             "--library=$<TARGET_FILE_BASE_NAME:${opt_TARGET}>"
+             "--library-path=$<TARGET_FILE_DIR:${opt_TARGET}>"

--- a/fix-uint64-angle-compiler.patch
+++ b/fix-uint64-angle-compiler.patch
@@ -1,0 +1,21 @@
+--- a/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
++++ b/Source/ThirdParty/ANGLE/src/compiler/translator/Compiler.cpp
+@@ -7,6 +7,7 @@
+ #include "compiler/translator/Compiler.h"
+ 
+ #include <sstream>
++#include <cstdint>
+ 
+ #include "angle_gl.h"
+ #include "common/utilities.h"
+ 
+--- a/Source/ThirdParty/ANGLE/include/GLSLANG/ShaderVars.h
++++ b/Source/ThirdParty/ANGLE/include/GLSLANG/ShaderVars.h
+@@ -14,6 +14,7 @@
+ #include <array>
+ #include <string>
+ #include <vector>
++#include <cstdint>
+ 
+ // This type is defined here to simplify ANGLE's integration with glslang for SPIR-V.
+ using ShCompileOptions = uint64_t;

--- a/net.poedit.Poedit.json
+++ b/net.poedit.Poedit.json
@@ -160,14 +160,21 @@
                     "-DCMAKE_BUILD_TYPE=Release",
                     "-DBUILD_TESTS=OFF",
                     "-DBUILD_SAMPLES=OFF",
-                    "-DCPPREST_EXCLUDE_WEBSOCKETS=OFF"
+                    "-DCPPREST_EXCLUDE_WEBSOCKETS=OFF",
+                    "-DCMAKE_COMPILE_WARNING_AS_ERROR=OFF"
                 ]
             },
-            "sources": [{
-                "type": "archive",
-                "url": "https://github.com/microsoft/cpprestsdk/archive/refs/tags/2.10.18.tar.gz",
-                "sha256": "6bd74a637ff182144b6a4271227ea8b6b3ea92389f88b25b215e6f94fd4d41cb"
-            }]
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/microsoft/cpprestsdk/archive/refs/tags/2.10.18.tar.gz",
+                    "sha256": "6bd74a637ff182144b6a4271227ea8b6b3ea92389f88b25b215e6f94fd4d41cb"
+                },
+                {
+                    "type": "patch",
+                    "path": "disable-cpprestsdk-cpp-warn-error.patch"
+                }
+            ]
         },
         {
             "name": "cld2",

--- a/net.poedit.Poedit.json
+++ b/net.poedit.Poedit.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.poedit.Poedit",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "44",
+    "runtime-version": "46",
     "sdk": "org.gnome.Sdk",
     "command": "poedit",
     "finish-args": [
@@ -41,13 +41,23 @@
                 "-DENABLE_DOCUMENTATION=OFF",
                 "-DENABLE_GAMEPAD=OFF",
                 "-DENABLE_WEBDRIVER=OFF",
-                "-DUSE_SOUP2=ON"
+                "-DUSE_SOUP2=ON",
+                "-DUSE_WPE_RENDERER=OFF",
+                "-DCMAKE_COMPILE_WARNING_AS_ERROR=OFF"
             ],
             "sources": [
                 {
                     "type": "archive",
                     "url": "https://webkitgtk.org/releases/webkitgtk-2.38.6.tar.xz",
                     "sha256": "1c614c9589389db1a79ea9ba4293bbe8ac3ab0a2234cac700935fae0724ad48b"
+                },
+                {
+                    "type": "patch",
+                    "path": "fix-uint64-angle-compiler.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "disable-webkit2-gi-warn-error.patch"
                 }
             ]
         },


### PR DESCRIPTION
This pull request introduces several updates to the `net.poedit.Poedit` project:

1. **Update Gnome Runtime**: The Gnome runtime has been updated to version 46. This update brings all the improvements and bug fixes from the latest Gnome runtime, ensuring that `net.poedit.Poedit` can take advantage of the most recent advancements in the Gnome platform.

2. **Disable Warn-Error**: A patch has been applied to disable the `--warn-error` flag in the GIR scanner command. This change will prevent the GIR scanner from treating warnings as errors and blocking the build process.

3. **Update ANGLE Compiler**: The Angle compiler has been updated with a patch for the `uint64` header. The include was missing which also blocked the build.

This is related to the issue: https://github.com/flathub/net.poedit.Poedit/issues/49

These changes aim to improve the overall performance and stability of the `net.poedit.Poedit` project. Feedback and reviews are welcome.