### PR TITLE
Update GNOME runtime to 48

### DIFF
--- a/net.poedit.Poedit.json
+++ b/net.poedit.Poedit.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.poedit.Poedit",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "48",
     "sdk": "org.gnome.Sdk",
     "command": "poedit",
     "finish-args": [

--- a/net.poedit.Poedit.json
+++ b/net.poedit.Poedit.json
@@ -115,7 +115,7 @@
             ],
             "sources": [{
                 "type": "archive",
-                "url": "https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2",
+                "url": "https://archives.boost.io/release/1.76.0/source/boost_1_76_0.tar.bz2",
                 "sha256": "f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41"
             }]
         },
@@ -141,7 +141,7 @@
                 "name": "enchant",
                 "sources": [{
                     "type": "archive",
-                    "url": "https://github.com/AbiWord/enchant/releases/download/v2.3.2/enchant-2.3.2.tar.gz",
+                    "url": "https://github.com/rrthomas/enchant/releases/download/v2.3.2/enchant-2.3.2.tar.gz",
                     "sha256": "ce9ba47fd4d34031bd69445598a698a6611602b2b0e91d705e91a6f5099ead6e"
                 }]
             }],

--- a/net.poedit.Poedit.json
+++ b/net.poedit.Poedit.json
@@ -94,8 +94,8 @@
             ],
             "sources": [{
                     "type": "archive",
-                    "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.2.1/wxWidgets-3.2.2.1.tar.bz2",
-                    "sha256": "dffcb6be71296fff4b7f8840eb1b510178f57aa2eb236b20da41182009242c02"
+                    "url": "https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.8/wxWidgets-3.2.8.tar.bz2",
+                    "sha256": "c74784904109d7229e6894c85cfa068f1106a4a07c144afd78af41f373ee0fe6"
                 },
                 {
                     "type": "shell",


### PR DESCRIPTION
Fixes #57
Fixes #49

Closes #47

~~I have never built this repository successfully yet because it overeats my RAM (32 GiB + Swap 8GiB) while building WebKitGTK :weary:~~

I can limit numbers of parallel jobs by specifying `--jobs 4` to flatpak-builder.

## Changes Summary
- Update GNOME runtime to 48
- Fix failing to download modules
    - Fix the error while downloading boost:  
    ```
    Downloading https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.bz2
    100   138  100   138    0     0    115      0  0:00:01  0:00:01 --:--:--   669
    100 11534  100 11534    0     0   4327      0  0:00:02  0:00:02 --:--:-- 20486
    Failed to download sources: module boost: Wrong sha256 checksum for boost_1_76_0.tar.bz2, expected "f0397ba6e982c4450f27bf32a2a83292aba035b827a5623a14636ea583318c41", was "79e6d3f986444e5a80afbeccdaf2d1c1cf964baa8d766d20859d653a16c39848"
    ```
    - and the error while downloading enchant:  
    ```
    Downloading https://github.com/AbiWord/enchant/releases/download/v2.3.2/enchant-2.3.2.tar.gz
      0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
    Failed to download sources: module enchant: The requested URL returned error: 404
    ```
- Update wxWidget and fix an issue that it's not detected when building POEdit  
    ```
    2025-04-16T16:36:00.2867989Z checking for wx-config... /app/bin/wx-config
    2025-04-16T16:36:00.3149119Z checking for wxWidgets version >= 3.0.3 (--unicode)... no
    2025-04-16T16:36:00.3149435Z configure: error: 
    2025-04-16T16:36:00.3149657Z         Please check that wx-config is in path, the directory
    2025-04-16T16:36:00.3149964Z         where wxWidgets libraries are installed (returned by
    2025-04-16T16:36:00.3150431Z         'wx-config --unicode --libs' command) is in LD_LIBRARY_PATH or
    2025-04-16T16:36:00.3150840Z         equivalent variable and wxWidgets is version 3.0.0 or above,
    2025-04-16T16:36:00.3151126Z         with Unicode build available.
    ```

## Checklist
- [x] Build succeeds locally with the following steps
    - `flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo`
    - `flatpak-builder --user --force-clean --install --install-deps-from=flathub --jobs 4 buildir net.poedit.Poedit.json`
- [x] POEdit launches and can save .po files successfully
