### PR TITLE
Update GNOME runtime to 50

### DIFF
--- a/net.poedit.Poedit.json
+++ b/net.poedit.Poedit.json
@@ -1,7 +1,7 @@
 {
     "app-id": "net.poedit.Poedit",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "49",
+    "runtime-version": "50",
     "sdk": "org.gnome.Sdk",
     "command": "poedit",
     "finish-args": [


### PR DESCRIPTION
## Changes Summary
- Update GNOME runtime to 50

## Checklist
- [x] Build succeeds locally with the following steps
    - `flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo`
    - `flatpak-builder --user --force-clean --install --install-deps-from=flathub buildir net.poedit.Poedit.json`
    - NOTE: required 8 GB memory; the build process was killed by OOM killer during build of poedit if I assign only 4 GB memory for my VM
- [x] Poedit launches and can save .po files successfully
